### PR TITLE
feat: pool sharing when calling With(), and WithGroup()

### DIFF
--- a/benchmark/fastlog_test.go
+++ b/benchmark/fastlog_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func BenchmarkFastlog_console_withoutCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.ConsoleFormat, ShowCaller: false})
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Console(), fastlog.WithoutCaller())
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -18,7 +18,7 @@ func BenchmarkFastlog_console_withoutCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_console_withCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.ConsoleFormat, ShowCaller: true})
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Console())
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -28,7 +28,7 @@ func BenchmarkFastlog_console_withCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_console_slog_withoutCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.ConsoleFormat, ShowCaller: false}).Slog()
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Console(), fastlog.WithoutCaller()).Slog()
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -38,7 +38,7 @@ func BenchmarkFastlog_console_slog_withoutCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_console_slog_withCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.ConsoleFormat, ShowCaller: true}).Slog()
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Console()).Slog()
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -48,7 +48,7 @@ func BenchmarkFastlog_console_slog_withCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_logfmt_withoutCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.LogfmtFormat, ShowCaller: false})
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Logfmt(), fastlog.WithoutCaller())
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -58,7 +58,7 @@ func BenchmarkFastlog_logfmt_withoutCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_logfmt_withCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.LogfmtFormat, ShowCaller: true})
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Logfmt())
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -68,7 +68,7 @@ func BenchmarkFastlog_logfmt_withCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_logfmt_slog_withoutCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.LogfmtFormat, ShowCaller: false}).Slog()
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Logfmt(), fastlog.WithoutCaller()).Slog()
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -78,7 +78,7 @@ func BenchmarkFastlog_logfmt_slog_withoutCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_logfmt_slog_withCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.LogfmtFormat, ShowCaller: true}).Slog()
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Logfmt()).Slog()
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -88,7 +88,7 @@ func BenchmarkFastlog_logfmt_slog_withCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_json_withoutCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.JSONFormat, ShowCaller: false})
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Json(), fastlog.WithoutCaller())
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -98,7 +98,7 @@ func BenchmarkFastlog_json_withoutCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_json_withCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.JSONFormat, ShowCaller: true})
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Json())
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -108,7 +108,7 @@ func BenchmarkFastlog_json_withCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_json_slog_withoutCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.JSONFormat, ShowCaller: false}).Slog()
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Json(), fastlog.WithoutCaller()).Slog()
 	b.ReportAllocs()
 	b.ResetTimer()
 
@@ -118,7 +118,7 @@ func BenchmarkFastlog_json_slog_withoutCaller(b *testing.B) {
 }
 
 func BenchmarkFastlog_json_slog_withCaller(b *testing.B) {
-	logger := fastlog.New(fastlog.Options{Writer: io.Discard, Format: fastlog.JSONFormat, ShowCaller: true}).Slog()
+	logger := fastlog.New(fastlog.WithWriter(io.Discard), fastlog.Json()).Slog()
 	b.ReportAllocs()
 	b.ResetTimer()
 

--- a/benchmark/slog_test.go
+++ b/benchmark/slog_test.go
@@ -6,8 +6,48 @@ import (
 	"testing"
 )
 
-func BenchmarkSlog_Info(b *testing.B) {
+func BenchmarkSlog_JSON(b *testing.B) {
 	handler := slog.NewJSONHandler(io.Discard, nil)
+	logger := slog.New(handler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		logger.Info("hello world", attrs...)
+	}
+}
+
+func BenchmarkSlog_Info_With_Caller(b *testing.B) {
+	handler := slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{
+		AddSource: true,
+	})
+	logger := slog.New(handler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		logger.Info("hello world", attrs...)
+	}
+}
+
+func BenchmarkSlog_Text(b *testing.B) {
+	handler := slog.NewTextHandler(io.Discard, nil)
+	logger := slog.New(handler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		logger.Info("hello world", attrs...)
+	}
+}
+
+func BenchmarkSlog_Text_With_Caller(b *testing.B) {
+	handler := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		AddSource: true,
+	})
 	logger := slog.New(handler)
 
 	b.ReportAllocs()

--- a/bufpool.go
+++ b/bufpool.go
@@ -10,46 +10,41 @@ import (
 )
 
 type Pool struct {
-	size int
-	opts *Options
-
+	newBuffer func() *Buffer
 	sync.Pool
 }
 
 func NewPool(opts *Options) *Pool {
+	newBuffer := func() *Buffer {
+		return &Buffer{
+			store:   make([]byte, 0, InitialBufSize),
+			Options: opts,
+		}
+	}
 	return &Pool{
-		size: 256,
-		opts: opts,
-
+		newBuffer: newBuffer,
 		Pool: sync.Pool{
 			New: func() any {
-				return &Buffer{
-					store:   make([]byte, 0, 256),
-					Options: opts,
-				}
+				return newBuffer()
 			},
 		},
 	}
 }
 
 func (p *Pool) Get() *Buffer {
-	v := p.Pool.Get()
-	if v == nil {
-		return &Buffer{
-			store:   make([]byte, 0, p.size),
-			Options: p.opts,
-		}
+	if v := p.Pool.Get(); v != nil {
+		return v.(*Buffer)
 	}
-	return v.(*Buffer)
+	return p.newBuffer()
 }
 
-func (p *Pool) Put(msg *Buffer) {
-	msg.Reset()
+func (p *Pool) Put(buf *Buffer) {
+	buf.Reset()
 	// If buffer has grown too large, replace it with a new smaller buffer
-	if cap(msg.store) > 4096 {
-		msg.store = make([]byte, 0, 256)
+	if cap(buf.store) > MaxBufSize {
+		buf = p.newBuffer()
 	}
-	p.Pool.Put(msg)
+	p.Pool.Put(buf)
 }
 
 type Buffer struct {
@@ -63,15 +58,15 @@ func (buf *Buffer) Appendf(s string, args ...any) {
 
 func (buf *Buffer) AppendLogLevel(lvl slog.Level) bool {
 	switch buf.Format {
-	case ConsoleFormat:
+	case logFormatConsole:
 	default:
-		buf.AppendAttrKey(buf.LevelFieldKey)
+		buf.AppendAttrKey(LevelFieldKey)
 		buf.AppendAttrSeparator()
 	}
 
 	switch lvl {
 	case slog.LevelDebug:
-		if buf.EnableColors {
+		if !buf.EnableColors {
 			buf.store = append(buf.store, FgWhite...)
 		}
 		buf.AppendAttrValue("DEBUG")
@@ -106,7 +101,7 @@ func (buf *Buffer) AppendAttrSeparator() {
 		buf.store = append(buf.store, ColorSeparator...)
 	}
 	switch buf.Format {
-	case JSONFormat:
+	case logFormatJSON:
 		buf.store = append(buf.store, ':')
 	default:
 		buf.store = append(buf.store, '=')
@@ -118,7 +113,7 @@ func (buf *Buffer) AppendAttrSeparator() {
 
 func (buf *Buffer) AppendComponentSeparator() {
 	switch buf.Format {
-	case JSONFormat:
+	case logFormatJSON:
 		buf.store = append(buf.store, ',')
 	default:
 		buf.store = append(buf.store, ' ')
@@ -127,8 +122,8 @@ func (buf *Buffer) AppendComponentSeparator() {
 
 func (buf *Buffer) AppendMsg(msg string) {
 	switch buf.Format {
-	case JSONFormat, LogfmtFormat:
-		buf.AppendAttrKey(buf.MessageFieldKey)
+	case logFormatJSON, logFormatLogFmt:
+		buf.AppendAttrKey(MessageFieldKey)
 		buf.AppendAttrSeparator()
 	}
 
@@ -147,7 +142,7 @@ func (buf *Buffer) AppendAttrKey(key any) {
 	}
 
 	switch buf.Format {
-	case JSONFormat:
+	case logFormatJSON:
 		buf.AppendWithQuote(key)
 	default:
 		buf.Append(key)
@@ -172,7 +167,7 @@ func (buf *Buffer) AppendAttrKeyColorReset() {
 
 func (buf *Buffer) AppendAttrValue(value any) {
 	switch buf.Format {
-	case JSONFormat:
+	case logFormatJSON:
 		buf.AppendWithQuote(value)
 	default:
 		buf.Append(value)
@@ -184,9 +179,9 @@ func (buf *Buffer) AppendCaller(skip int) bool {
 		_, file, line, ok := runtime.Caller(skip + 1)
 		if ok {
 			switch buf.Format {
-			case ConsoleFormat:
+			case logFormatConsole:
 			default:
-				buf.AppendAttrKey(buf.CallerFieldKey)
+				buf.AppendAttrKey(CallerFieldKey)
 				buf.AppendAttrSeparator()
 				buf.Append('"')
 				defer buf.Append('"')
@@ -198,7 +193,7 @@ func (buf *Buffer) AppendCaller(skip int) bool {
 
 			trimCallerPath(buf, file, 2)
 			buf.Append(':')
-			if buf.Format == ConsoleFormat {
+			if buf.Format == logFormatConsole {
 				buf.Appendf("%-3d", line)
 			} else {
 				buf.Append(line)
@@ -212,9 +207,9 @@ func (buf *Buffer) AppendCaller(skip int) bool {
 func (buf *Buffer) AppendTimestamp() bool {
 	if buf.ShowTimestamp {
 		switch buf.Format {
-		case ConsoleFormat:
+		case logFormatConsole:
 		default:
-			buf.AppendAttrKey(buf.TimestampFieldKey)
+			buf.AppendAttrKey(TimestampFieldKey)
 			buf.AppendAttrSeparator()
 			buf.Append('"')
 			defer buf.Append('"')
@@ -224,7 +219,7 @@ func (buf *Buffer) AppendTimestamp() bool {
 			buf.Append(FgBrightBlack)
 		}
 
-		buf.Append(time.Now().Format(buf.TimestampFormat))
+		buf.Append(time.Now().Format(TimestampFormat))
 		return true
 	}
 
@@ -246,7 +241,7 @@ func (buf *Buffer) Append(b any, quote ...bool) {
 	case string:
 		buf.store = append(buf.store, v...)
 	case time.Time:
-		buf.store = append(buf.store, v.Format(buf.TimestampFormat)...)
+		buf.store = append(buf.store, v.Format(TimestampFormat)...)
 	case fmt.Stringer:
 		buf.store = append(buf.store, v.String()...)
 

--- a/console-fmt-slog.go
+++ b/console-fmt-slog.go
@@ -57,8 +57,17 @@ func (l *consoleLoggerSlog) Enabled(ctx context.Context, lvl slog.Level) bool {
 func (l *consoleLoggerSlog) Handle(ctx context.Context, record slog.Record) error {
 	buf := l.pool.Get()
 
-	buf.AppendCaller(3 + l.SkipCallerFrames)
-	buf.AppendComponentSeparator()
+	if buf.AppendTimestamp() {
+		buf.Appendf(" | ")
+		buf.AppendComponentSeparator()
+	}
+
+	if buf.AppendCaller(3 + l.SkipCallerFrames) {
+		buf.AppendComponentSeparator()
+		buf.Append('|')
+		buf.AppendComponentSeparator()
+	}
+
 	buf.AppendLogLevel(record.Level)
 	buf.AppendComponentSeparator()
 	buf.Append('|')
@@ -91,7 +100,7 @@ func (l *consoleLoggerSlog) Handle(ctx context.Context, record slog.Record) erro
 func (l *consoleLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &consoleLoggerSlog{
 		loggerProps: &loggerProps{
-			pool:    NewPool(&l.Options),
+			pool:    l.pool,
 			attrs:   append(l.attrs, attrs...),
 			Options: l.Options,
 		},
@@ -102,7 +111,7 @@ func (l *consoleLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (l *consoleLoggerSlog) WithGroup(name string) slog.Handler {
 	return &consoleLoggerSlog{
 		loggerProps: &loggerProps{
-			pool:   NewPool(&l.Options),
+			pool:   l.pool,
 			attrs:  l.attrs,
 			prefix: name + "." + l.prefix,
 

--- a/console-fmt.go
+++ b/console-fmt.go
@@ -50,15 +50,8 @@ func (c *consoleLogger) Slog() *slog.Logger {
 }
 
 // Clone implements loggerAPI.
-func (c *consoleLogger) Clone(options ...Options) *Logger {
-	opts := Options{}
-	if len(options) >= 1 {
-		opts = options[0]
-	}
-
-	opts = c.loggerProps.Options.clone(opts)
-
-	opts.withDefaults()
+func (c *consoleLogger) Clone(options ...OptionFn) *Logger {
+	opts := c.loggerProps.Options.clone(options...)
 
 	return &Logger{
 		loggerAPI: &consoleLogger{

--- a/console-fmt.go
+++ b/console-fmt.go
@@ -37,7 +37,7 @@ func (c *consoleLogger) With(kv ...any) *Logger {
 			loggerProps: &loggerProps{
 				attrs:   c.loggerProps.attrs,
 				prefix:  c.loggerProps.prefix,
-				pool:    NewPool(&c.loggerProps.Options),
+				pool:    c.loggerProps.pool,
 				Options: c.loggerProps.Options,
 			},
 		},

--- a/example/example.go
+++ b/example/example.go
@@ -46,17 +46,14 @@ func main() {
 		},
 	}
 
-	logfmt := fastlog.New(fastlog.Options{
-		Format: fastlog.LogfmtFormat, ShowCaller: true, EnableColors: true, ShowDebugLogs: *debug,
-		ShowTimestamp: true,
-	})
+	logfmt := fastlog.New(fastlog.Logfmt(), fastlog.ShowDebugLogs(*debug))
 	fmt.Printf("# LOGFMT:\n\n")
 	logfmt.Debug("hello", attrs...)
 	logfmt.Info("hello", attrs...)
 	logfmt.Warn("hello", attrs...)
 	logfmt.Error("hello", attrs...)
 
-	logfmt.Clone(fastlog.Options{SkipCallerFrames: 0}).Info("hello [from clone]", attrs...)
+	logfmt.Clone().Info("hello [from clone]", attrs...)
 
 	fmt.Printf("\n# LOGFMT (slog):\n\n")
 	logfmtSlog := logfmt.Slog()
@@ -65,16 +62,15 @@ func main() {
 	logfmtSlog.Warn("hello", attrs...)
 	logfmtSlog.Error("hello", attrs...)
 
-	consolefmt := fastlog.New(fastlog.Options{
-		Format: fastlog.ConsoleFormat, ShowCaller: true, EnableColors: true, ShowDebugLogs: *debug,
-		ShowTimestamp: true,
-	})
+	consolefmt := fastlog.New(fastlog.Console(), fastlog.ShowDebugLogs(*debug))
+
 	fmt.Printf("\n# CONSOLE:\n\n")
 	consolefmt.Debug("hello", attrs...)
 	consolefmt.Info("hello", attrs...)
 	consolefmt.Warn("hello", attrs...)
 	consolefmt.Error("hello", attrs...)
-	consolefmt.Clone(fastlog.Options{SkipCallerFrames: 0}).Info("hello [from clone]", attrs...)
+
+	consolefmt.Clone().Info("hello [from clone]", attrs...)
 
 	fmt.Printf("\n# CONSOLE (slog):\n\n")
 	consoleFmtSlog := consolefmt.Slog()
@@ -83,13 +79,14 @@ func main() {
 	consoleFmtSlog.Warn("hello", attrs...)
 	consoleFmtSlog.Error("hello", attrs...)
 
-	jsonfmt := fastlog.New(fastlog.Options{Format: fastlog.JSONFormat, ShowCaller: true, EnableColors: true, ShowDebugLogs: *debug})
+	jsonfmt := fastlog.New(fastlog.Json(), fastlog.ShowDebugLogs(*debug))
+
 	fmt.Printf("\n# JSON:\n\n")
 	jsonfmt.Debug("hello", attrs...)
 	jsonfmt.Info("hello", attrs...)
 	jsonfmt.Warn("hello", attrs...)
 	jsonfmt.Error("hello", attrs...)
-	jsonfmt.Clone(fastlog.Options{SkipCallerFrames: 0}).Info("hello [from clone]", attrs...)
+	jsonfmt.Clone().Info("hello [from clone]", attrs...)
 
 	fmt.Printf("\n# JSON (slog):\n\n")
 	jsonFmtSlog := jsonfmt.Slog()

--- a/json-fmt-slog.go
+++ b/json-fmt-slog.go
@@ -84,7 +84,7 @@ func (j *jsonLoggerSlog) Handle(_ context.Context, record slog.Record) error {
 func (j *jsonLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &jsonLoggerSlog{
 		loggerProps: &loggerProps{
-			pool:    NewPool(&j.Options),
+			pool:    j.pool,
 			attrs:   append(j.attrs, attrs...),
 			Options: j.Options,
 		},
@@ -95,7 +95,7 @@ func (j *jsonLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (j *jsonLoggerSlog) WithGroup(name string) slog.Handler {
 	return &jsonLoggerSlog{
 		loggerProps: &loggerProps{
-			pool:    NewPool(&j.Options),
+			pool:    j.pool,
 			attrs:   j.attrs,
 			prefix:  name + "." + j.prefix,
 			Options: j.Options,

--- a/json-fmt.go
+++ b/json-fmt.go
@@ -37,7 +37,7 @@ func (j *jsonLogger) With(kv ...any) *Logger {
 			loggerProps: &loggerProps{
 				attrs:   j.loggerProps.attrs,
 				prefix:  j.loggerProps.prefix,
-				pool:    NewPool(&j.loggerProps.Options),
+				pool:    j.loggerProps.pool,
 				Options: j.loggerProps.Options,
 			},
 		},

--- a/json-fmt.go
+++ b/json-fmt.go
@@ -50,14 +50,8 @@ func (j *jsonLogger) Slog() *slog.Logger {
 }
 
 // Clone implements loggerAPI.
-func (c *jsonLogger) Clone(options ...Options) *Logger {
-	opts := Options{}
-	if len(options) >= 1 {
-		opts = options[0]
-	}
-
-	opts = c.loggerProps.Options.clone(opts)
-	opts.withDefaults()
+func (c *jsonLogger) Clone(options ...OptionFn) *Logger {
+	opts := c.loggerProps.Options.clone(options...)
 
 	return &Logger{
 		loggerAPI: &jsonLogger{

--- a/logfmt-slog.go
+++ b/logfmt-slog.go
@@ -89,7 +89,7 @@ func (l *logfmtSlog) Handle(ctx context.Context, record slog.Record) error {
 func (l *logfmtSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &logfmtSlog{
 		loggerProps: &loggerProps{
-			pool:    NewPool(&l.Options),
+			pool:    l.pool,
 			attrs:   append(l.attrs, attrs...),
 			Options: l.Options,
 		},
@@ -100,7 +100,7 @@ func (l *logfmtSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 func (l *logfmtSlog) WithGroup(name string) slog.Handler {
 	return &logfmtSlog{
 		loggerProps: &loggerProps{
-			pool:   NewPool(&l.Options),
+			pool:   l.pool,
 			attrs:  l.attrs,
 			prefix: name + "." + l.prefix,
 

--- a/logfmt.go
+++ b/logfmt.go
@@ -49,15 +49,8 @@ func (l *logfmtLogger) Slog() *slog.Logger {
 }
 
 // Clone implements loggerAPI.
-func (c *logfmtLogger) Clone(options ...Options) *Logger {
-	opts := Options{}
-	if len(options) >= 1 {
-		opts = options[0]
-	}
-
-	opts = c.loggerProps.Options.clone(opts)
-
-	opts.withDefaults()
+func (c *logfmtLogger) Clone(options ...OptionFn) *Logger {
+	opts := c.loggerProps.Options.clone(options...)
 
 	return &Logger{
 		loggerAPI: &logfmtLogger{
@@ -101,7 +94,10 @@ func (l *logfmtLogger) handleLog(level slog.Level, msg string, kv ...any) error 
 	}
 
 	buf.Append('\n')
-	_, err := l.Writer.Write(buf.Bytes())
+	if _, err := l.Writer.Write(buf.Bytes()); err != nil {
+		return err
+	}
+
 	l.pool.Put(buf)
-	return err
+	return nil
 }

--- a/logfmt.go
+++ b/logfmt.go
@@ -37,7 +37,7 @@ func (l *logfmtLogger) With(kv ...any) *Logger {
 			loggerProps: &loggerProps{
 				attrs:   l.loggerProps.attrs,
 				prefix:  l.loggerProps.prefix,
-				pool:    NewPool(&l.loggerProps.Options),
+				pool:    l.loggerProps.pool,
 				Options: l.loggerProps.Options,
 			},
 		},

--- a/logger.go
+++ b/logger.go
@@ -78,7 +78,7 @@ func (opts *Options) withDefaults() {
 }
 
 func (opts Options) clone(opt2 Options) Options {
-	if opt2.Writer == nil {
+	if opt2.Writer != nil {
 		opts.Writer = opt2.Writer
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -18,108 +18,133 @@ type loggerProps struct {
 type logformat string
 
 const (
-	ConsoleFormat logformat = "console"
-	JSONFormat    logformat = "json"
-	LogfmtFormat  logformat = "logfmt"
+	logFormatConsole logformat = "console"
+	logFormatJSON    logformat = "json"
+	logFormatLogFmt  logformat = "logfmt"
+)
+
+var (
+	LevelFieldKey   string = "level"
+	CallerFieldKey  string = "caller"
+	MessageFieldKey string = "message"
+
+	TimestampFieldKey string = "timestamp"
+	TimestampFormat   string = time.RFC3339
+)
+
+var (
+	InitialBufSize int = 256
+	MaxBufSize     int = 4096
 )
 
 type Options struct {
-	Writer   io.Writer
-	Format   logformat
+	Writer io.Writer
+	Format logformat
+
 	LogLevel slog.Level
 
-	// ShowDebugLogs sets LogLevel to Debug
+	// ShowDebugLogs and LogLevel are mutually exclusive, as ShowDebugLogs set LogLevel to Debug regardless of LogLevel field being set or not
 	ShowDebugLogs bool
-	ShowCaller    bool
+
+	ShowCaller bool
+
 	ShowTimestamp bool
+	EnableColors  bool
 
 	SkipCallerFrames int
-
-	EnableColors bool
-
-	TimestampFieldKey string
-	TimestampFormat   string
-
-	MessageFieldKey string
-	LevelFieldKey   string
-	CallerFieldKey  string
 }
 
-func (opts *Options) withDefaults() {
-	if opts.Writer == nil {
-		opts.Writer = os.Stderr
-	}
+type OptionFn func(opt *Options)
 
-	opts.Writer = &syncWriter{writer: opts.Writer}
-
-	if opts.TimestampFieldKey == "" {
-		opts.TimestampFieldKey = "ts"
-	}
-
-	if opts.TimestampFormat == "" {
-		opts.TimestampFormat = time.RFC3339
-	}
-
-	if opts.MessageFieldKey == "" {
-		opts.MessageFieldKey = "message"
-	}
-
-	if opts.LevelFieldKey == "" {
-		opts.LevelFieldKey = "level"
-	}
-
-	if opts.CallerFieldKey == "" {
-		opts.CallerFieldKey = "caller"
-	}
-
-	if opts.ShowDebugLogs {
-		opts.LogLevel = slog.LevelDebug
+func WithWriter(writer io.Writer) OptionFn {
+	return func(opt *Options) {
+		opt.Writer = writer
 	}
 }
 
-func (opts Options) clone(opt2 Options) Options {
-	if opt2.Writer != nil {
-		opts.Writer = opt2.Writer
+func WithLogLevel(level slog.Level) OptionFn {
+	return func(opt *Options) {
+		opt.LogLevel = level
+	}
+}
+
+func WithoutCaller() OptionFn {
+	return func(opt *Options) {
+		opt.ShowCaller = false
+	}
+}
+
+func ShowDebugLogs(enabled bool) OptionFn {
+	return func(opt *Options) {
+		opt.ShowDebugLogs = enabled
+	}
+}
+
+func SkipCallerFrames(count int) OptionFn {
+	return func(opt *Options) {
+		opt.SkipCallerFrames = count
+	}
+}
+
+func Json() OptionFn {
+	return func(opt *Options) {
+		opt.Format = logFormatJSON
+	}
+}
+
+func Logfmt() OptionFn {
+	return func(opt *Options) {
+		opt.Format = logFormatLogFmt
+	}
+}
+
+func Console() OptionFn {
+	return func(opt *Options) {
+		opt.Format = logFormatConsole
+	}
+}
+
+func WithoutColors() OptionFn {
+	return func(opt *Options) {
+		opt.EnableColors = false
+	}
+}
+
+func WithoutTimestamp() OptionFn {
+	return func(opt *Options) {
+		opt.ShowTimestamp = false
+	}
+}
+
+func (opts Options) clone(options ...OptionFn) Options {
+	for _, optFn := range options {
+		optFn(&opts)
 	}
 
-	if opt2.TimestampFieldKey != "" {
-		opts.TimestampFieldKey = opt2.TimestampFieldKey
-	}
-
-	if opt2.TimestampFormat != "" {
-		opts.TimestampFormat = opt2.TimestampFormat
-	}
-
-	if opt2.MessageFieldKey != "" {
-		opts.MessageFieldKey = opt2.MessageFieldKey
-	}
-
-	if opt2.LevelFieldKey != "" {
-		opts.LevelFieldKey = opt2.LevelFieldKey
-	}
-
-	if opt2.CallerFieldKey != "" {
-		opts.CallerFieldKey = opt2.CallerFieldKey
-	}
-
-	if opts.ShowDebugLogs || opt2.ShowDebugLogs {
-		opts.LogLevel = slog.LevelDebug
-	}
-
-	if opt2.SkipCallerFrames > 0 {
-		opts.SkipCallerFrames = opt2.SkipCallerFrames
+	if _, ok := opts.Writer.(*syncWriter); !ok {
+		opts.Writer = &syncWriter{writer: opts.Writer}
 	}
 
 	return opts
 }
 
-func New(options ...Options) *Logger {
-	opts := Options{}
-	if len(options) > 0 {
-		opts = options[0]
+func New(options ...OptionFn) *Logger {
+	opts := Options{
+		Writer:           os.Stderr,
+		Format:           logFormatConsole,
+		LogLevel:         slog.LevelInfo,
+		ShowDebugLogs:    false,
+		ShowCaller:       true,
+		ShowTimestamp:    false,
+		EnableColors:     true,
+		SkipCallerFrames: 0,
 	}
 
-	opts.withDefaults()
+	for _, optFn := range options {
+		optFn(&opts)
+	}
+
+	opts.Writer = &syncWriter{writer: opts.Writer}
 
 	props := &loggerProps{
 		attrs:  nil,
@@ -130,11 +155,11 @@ func New(options ...Options) *Logger {
 	}
 
 	switch opts.Format {
-	case ConsoleFormat:
+	case logFormatConsole:
 		return &Logger{loggerAPI: &consoleLogger{kv: nil, loggerProps: props}}
-	case LogfmtFormat:
+	case logFormatLogFmt:
 		return &Logger{loggerAPI: &logfmtLogger{kv: nil, loggerProps: props}}
-	case JSONFormat:
+	case logFormatJSON:
 		return &Logger{loggerAPI: &jsonLogger{kv: nil, loggerProps: props}}
 	default:
 		return &Logger{loggerAPI: &consoleLogger{kv: nil, loggerProps: props}}
@@ -150,7 +175,7 @@ type loggerAPI interface {
 	With(kv ...any) *Logger
 	Slog() *slog.Logger
 
-	Clone(option ...Options) *Logger
+	Clone(option ...OptionFn) *Logger
 }
 
 type Logger struct {


### PR DESCRIPTION
## Summary by Sourcery

Refactor logger configuration to a functional options pattern, centralize default constants, improve buffer pool management with pruning, ensure pool sharing in cloned loggers, and update examples and benchmarks to the new API.

New Features:
- Add functional options API for configuring loggers (WithWriter, WithLogLevel, Console, Json, Logfmt, etc.)
- Introduce global default keys and timestamp format constants

Bug Fixes:
- Share the same buffer pool in With()/WithGroup() instead of creating new pools
- Ensure write errors are correctly returned in handleLog

Enhancements:
- Rename logformat constants to unexported identifiers and streamline format-specific logic
- Enhance buffer pool with configurable InitialBufSize/MaxBufSize and prune oversized buffers
- Refactor Buffer append methods to use shared field key constants and simplify quoting logic
- Update example code and benchmarks to use the new functional options API

Tests:
- Add new slog benchmark variants for JSON/text formatting with and without caller info
- Rename BenchmarkSlog_Info to BenchmarkSlog_JSON