### PR TITLE
test: adding tests to fastlog

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+name: Go Tests
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download -x
+
+      - name: Run tests
+        run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           cache: true
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 *.out
 *.test
 bin/
+.secrets

--- a/bufpool.go
+++ b/bufpool.go
@@ -2,12 +2,12 @@ package fastlog
 
 import (
 	"fmt"
+	"github.com/nxtcoder17/fastlog/types"
 	"log/slog"
 	"runtime"
 	"strconv"
 	"sync"
 	"time"
-	"github.com/nxtcoder17/fastlog/types"
 )
 
 type Pool struct {
@@ -17,8 +17,8 @@ type Pool struct {
 
 type bufferPoolOptions struct {
 	WithTimestamp bool
-	WithColors bool
-	WithCaller bool
+	WithColors    bool
+	WithCaller    bool
 
 	LogFormat types.LogFormat
 }
@@ -26,8 +26,8 @@ type bufferPoolOptions struct {
 func newPool(opts *bufferPoolOptions) *Pool {
 	newBuffer := func() *Buffer {
 		return &Buffer{
-			store:   make([]byte, 0, InitialBufSize),
-			opts: opts,
+			store: make([]byte, 0, InitialBufSize),
+			opts:  opts,
 		}
 	}
 	return &Pool{
@@ -58,7 +58,7 @@ func (p *Pool) Put(buf *Buffer) {
 
 type Buffer struct {
 	store []byte
-	opts *bufferPoolOptions
+	opts  *bufferPoolOptions
 }
 
 func (buf *Buffer) Appendf(s string, args ...any) {
@@ -75,7 +75,7 @@ func (buf *Buffer) AppendLogLevel(lvl slog.Level) bool {
 
 	switch lvl {
 	case slog.LevelDebug:
-		if !buf.opts.WithColors {
+		if buf.opts.WithColors {
 			buf.store = append(buf.store, FgWhite...)
 		}
 		buf.AppendAttrValue("DEBUG")

--- a/console-fmt-slog.go
+++ b/console-fmt-slog.go
@@ -6,15 +6,15 @@ import (
 )
 
 type consoleLoggerSlog struct {
-	kv  []slog.Attr
+	kv     []slog.Attr
 	prefix string
 	pool   *Pool
-	opts *Options
+	opts   *Options
 }
 
 func (l *consoleLoggerSlog) parseAttr(buf *Buffer, attr slog.Attr) {
 	buf.AppendAttrKeyColor()
-if l.prefix != "" {
+	if l.prefix != "" {
 		buf.Append(l.prefix)
 		buf.Append(".")
 	}
@@ -61,7 +61,8 @@ func (l *consoleLoggerSlog) Handle(ctx context.Context, record slog.Record) erro
 	buf := l.pool.Get()
 
 	if buf.AppendTimestamp() {
-		buf.Appendf(" | ")
+		buf.AppendComponentSeparator()
+		buf.Append('|')
 		buf.AppendComponentSeparator()
 	}
 
@@ -82,13 +83,9 @@ func (l *consoleLoggerSlog) Handle(ctx context.Context, record slog.Record) erro
 		buf.Append('\t')
 	}
 
-	c := 0
 	record.AddAttrs(l.kv...)
 	record.Attrs(func(a slog.Attr) bool {
-		if c <= record.NumAttrs() {
-			buf.AppendComponentSeparator()
-		}
-		c += 1
+		buf.AppendComponentSeparator()
 		l.parseAttr(buf, a)
 		return true
 	})
@@ -101,11 +98,11 @@ func (l *consoleLoggerSlog) Handle(ctx context.Context, record slog.Record) erro
 
 // WithAttrs implements slog.Handler.
 func (l *consoleLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
-	kv := make([]slog.Attr, 0, len(l.kv) + len(attrs))
+	kv := make([]slog.Attr, 0, len(l.kv)+len(attrs))
 	kv = append(kv, l.kv...)
 	kv = append(kv, attrs...)
 
-	return  &consoleLoggerSlog{
+	return &consoleLoggerSlog{
 		pool:   l.pool,
 		prefix: l.prefix,
 		kv:     kv,
@@ -115,11 +112,15 @@ func (l *consoleLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
 
 // WithGroup implements slog.Handler.
 func (l *consoleLoggerSlog) WithGroup(name string) slog.Handler {
+	newPrefix := name
+	if l.prefix != "" {
+		newPrefix = l.prefix + "." + name
+	}
 	return &consoleLoggerSlog{
 		pool:   l.pool,
-		prefix: name + "." + l.prefix,
-		kv:  l.kv,
-		opts: l.opts,
+		prefix: newPrefix,
+		kv:     l.kv,
+		opts:   l.opts,
 	}
 }
 

--- a/console-fmt.go
+++ b/console-fmt.go
@@ -5,10 +5,10 @@ import (
 )
 
 type consoleLogger struct {
-	kv []any
+	kv     []any
 	prefix string
-	opts *Options
-	pool *Pool
+	opts   *Options
+	pool   *Pool
 }
 
 // Debug implements loggerAPI.
@@ -33,38 +33,40 @@ func (c *consoleLogger) Warn(msg string, kv ...any) {
 
 // With implements loggerAPI.
 func (c *consoleLogger) With(kv ...any) Logger {
-	newKVs := make([]any, 0, len(kv) + len(c.kv))
+	newKVs := make([]any, 0, len(kv)+len(c.kv))
 	newKVs = append(newKVs, c.kv...)
 	newKVs = append(newKVs, kv...)
 
 	return &consoleLogger{
-		kv: newKVs,
+		kv:     newKVs,
 		prefix: c.prefix,
-		opts: c.opts,
-		pool: c.pool,
+		opts:   c.opts,
+		pool:   c.pool,
 	}
 }
 
 // Slog implements loggerAPI.
 func (c *consoleLogger) Slog() *slog.Logger {
 	kv := make([]slog.Attr, 0, len(c.kv))
-	for i := 1; i < len(c.kv); i+=2 {
+	for i := 1; i < len(c.kv); i += 2 {
 		kv = append(kv, slog.Any(c.kv[i-1].(string), c.kv[i]))
 	}
 
 	return slog.New(&consoleLoggerSlog{
-		kv: kv,
+		kv:     kv,
 		prefix: c.prefix,
-		pool: c.pool,
-		opts: c.opts,
+		pool:   c.pool,
+		opts:   c.opts,
 	})
 }
 
 // Clone implements loggerAPI.
 func (c *consoleLogger) Clone() *loggerBuilder {
+	optsCopy := *c.opts
 	return &loggerBuilder{
-		prefix: c.prefix,
-		options: c.opts,
+		prefix:  c.prefix,
+		options: &optsCopy,
+		kv:      c.kv,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/nxtcoder17/fastlog
 
-go 1.20
+go 1.21

--- a/json-fmt-slog.go
+++ b/json-fmt-slog.go
@@ -6,10 +6,10 @@ import (
 )
 
 type jsonLoggerSlog struct {
-	kv []slog.Attr
+	kv     []slog.Attr
 	prefix string
-	opts *Options
-	pool *Pool
+	opts   *Options
+	pool   *Pool
 }
 
 func (j *jsonLoggerSlog) parseAttr(buf *Buffer, attr slog.Attr) {
@@ -57,21 +57,19 @@ func (j *jsonLoggerSlog) Enabled(_ context.Context, lvl slog.Level) bool {
 func (j *jsonLoggerSlog) Handle(_ context.Context, record slog.Record) error {
 	buf := j.pool.Get()
 	buf.Append("{")
-	buf.AppendCaller(3 + j.opts.SkipCallerFrames)
-	buf.AppendComponentSeparator()
+
+	if buf.AppendCaller(3 + j.opts.SkipCallerFrames) {
+		buf.AppendComponentSeparator()
+	}
 
 	buf.AppendLogLevel(record.Level)
 	buf.AppendComponentSeparator()
 
 	buf.AppendMsg(record.Message)
 
-	c := 0
 	record.AddAttrs(j.kv...)
 	record.Attrs(func(a slog.Attr) bool {
-		if c <= record.NumAttrs() {
-			buf.AppendComponentSeparator()
-		}
-		c += 1
+		buf.AppendComponentSeparator()
 		j.parseAttr(buf, a)
 		return true
 	})
@@ -85,26 +83,29 @@ func (j *jsonLoggerSlog) Handle(_ context.Context, record slog.Record) error {
 
 // WithAttrs implements slog.Handler.
 func (j *jsonLoggerSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
-	kv := make([]slog.Attr, 0, len(j.kv) + len(attrs))
+	kv := make([]slog.Attr, 0, len(j.kv)+len(attrs))
 	kv = append(kv, j.kv...)
 	kv = append(kv, attrs...)
 
-
 	return &jsonLoggerSlog{
-		kv: kv,
+		kv:     kv,
 		prefix: j.prefix,
-		pool:    j.pool,
-		opts: j.opts,
+		pool:   j.pool,
+		opts:   j.opts,
 	}
 }
 
 // WithGroup implements slog.Handler.
 func (j *jsonLoggerSlog) WithGroup(name string) slog.Handler {
+	newPrefix := name
+	if j.prefix != "" {
+		newPrefix = j.prefix + "." + name
+	}
 	return &jsonLoggerSlog{
-		kv:   j.kv,
-		prefix:  name + "." + j.prefix,
-		pool:    j.pool,
-		opts: j.opts,
+		kv:     j.kv,
+		prefix: newPrefix,
+		pool:   j.pool,
+		opts:   j.opts,
 	}
 }
 

--- a/json-fmt.go
+++ b/json-fmt.go
@@ -5,10 +5,10 @@ import (
 )
 
 type jsonLogger struct {
-	kv []any
+	kv     []any
 	prefix string
-	opts *Options
-	pool *Pool
+	opts   *Options
+	pool   *Pool
 }
 
 // Debug implements loggerAPI.
@@ -33,38 +33,40 @@ func (j *jsonLogger) Warn(msg string, kv ...any) {
 
 // With implements loggerAPI.
 func (j *jsonLogger) With(kv ...any) Logger {
-	newKVs := make([]any, 0, len(kv) + len(j.kv))
+	newKVs := make([]any, 0, len(kv)+len(j.kv))
 	newKVs = append(newKVs, j.kv...)
 	newKVs = append(newKVs, kv...)
 
 	return &jsonLogger{
-		kv: newKVs,
-		prefix:  j.prefix,
-		pool:    j.pool,
-		opts: j.opts,
+		kv:     newKVs,
+		prefix: j.prefix,
+		pool:   j.pool,
+		opts:   j.opts,
 	}
 }
 
 // Slog implements loggerAPI.
 func (j *jsonLogger) Slog() *slog.Logger {
 	kv := make([]slog.Attr, 0, len(j.kv))
-	for i := 1; i < len(j.kv); i+=2 {
+	for i := 1; i < len(j.kv); i += 2 {
 		kv = append(kv, slog.Any(j.kv[i-1].(string), j.kv[i]))
 	}
 
 	return slog.New(&jsonLoggerSlog{
-		kv: kv,
+		kv:     kv,
 		prefix: j.prefix,
-		pool: j.pool,
-		opts: j.opts,
+		pool:   j.pool,
+		opts:   j.opts,
 	})
 }
 
 // Clone implements loggerAPI.
 func (j *jsonLogger) Clone() *loggerBuilder {
+	optsCopy := *j.opts
 	return &loggerBuilder{
-		options: j.opts,
-		prefix: j.prefix,
+		options: &optsCopy,
+		prefix:  j.prefix,
+		kv:      j.kv,
 	}
 }
 
@@ -79,8 +81,16 @@ func (j *jsonLogger) handleLog(level slog.Level, msg string, kv ...any) error {
 
 	buf.Append("{")
 
-	buf.AppendCaller(2 + j.opts.SkipCallerFrames)
-	buf.AppendComponentSeparator()
+	needSep := false
+	if buf.AppendTimestamp() {
+		needSep = true
+	}
+	if buf.AppendCaller(2 + j.opts.SkipCallerFrames) {
+		needSep = true
+	}
+	if needSep {
+		buf.AppendComponentSeparator()
+	}
 
 	buf.AppendLogLevel(level)
 	buf.AppendComponentSeparator()

--- a/logfmt-slog.go
+++ b/logfmt-slog.go
@@ -6,10 +6,10 @@ import (
 )
 
 type logfmtSlog struct {
-	kv  []slog.Attr
+	kv     []slog.Attr
 	pool   *Pool
 	prefix string
-	opts *Options
+	opts   *Options
 }
 
 var _ slog.Handler = (*logfmtSlog)(nil)
@@ -61,8 +61,12 @@ func (l *logfmtSlog) Enabled(ctx context.Context, lvl slog.Level) bool {
 func (l *logfmtSlog) Handle(ctx context.Context, record slog.Record) error {
 	buf := l.pool.Get()
 
-	buf.AppendCaller(3 + l.opts.SkipCallerFrames)
-	buf.AppendComponentSeparator()
+	if buf.AppendTimestamp() {
+		buf.AppendComponentSeparator()
+	}
+	if buf.AppendCaller(3 + l.opts.SkipCallerFrames) {
+		buf.AppendComponentSeparator()
+	}
 
 	buf.AppendLogLevel(record.Level)
 	buf.AppendComponentSeparator()
@@ -70,13 +74,9 @@ func (l *logfmtSlog) Handle(ctx context.Context, record slog.Record) error {
 	buf.AppendMsg(record.Message)
 	buf.AppendComponentSeparator()
 
-	c := 0
 	record.AddAttrs(l.kv...)
 	record.Attrs(func(a slog.Attr) bool {
-		if c <= record.NumAttrs() {
-			buf.AppendComponentSeparator()
-		}
-		c += 1
+		buf.AppendComponentSeparator()
 		l.parseAttr(buf, a)
 		return true
 	})
@@ -90,24 +90,28 @@ func (l *logfmtSlog) Handle(ctx context.Context, record slog.Record) error {
 
 // WithAttrs implements slog.Handler.
 func (l *logfmtSlog) WithAttrs(attrs []slog.Attr) slog.Handler {
-	kv := make([]slog.Attr, 0, len(l.kv)+ len(attrs))
+	kv := make([]slog.Attr, 0, len(l.kv)+len(attrs))
 	kv = append(kv, l.kv...)
 	kv = append(kv, attrs...)
 
 	return &logfmtSlog{
-		kv:    kv,
+		kv:     kv,
 		prefix: l.prefix,
-		pool: l.pool,
-		opts: l.opts,
+		pool:   l.pool,
+		opts:   l.opts,
 	}
 }
 
 // WithGroup implements slog.Handler.
 func (l *logfmtSlog) WithGroup(name string) slog.Handler {
+	newPrefix := name
+	if l.prefix != "" {
+		newPrefix = l.prefix + "." + name
+	}
 	return &logfmtSlog{
-		kv:  l.kv,
-		prefix: name + "." + l.prefix,
+		kv:     l.kv,
+		prefix: newPrefix,
 		pool:   l.pool,
-		opts: l.opts,
+		opts:   l.opts,
 	}
 }

--- a/logfmt.go
+++ b/logfmt.go
@@ -5,10 +5,10 @@ import (
 )
 
 type logfmtLogger struct {
-	kv []any
+	kv     []any
 	prefix string
-	opts *Options
-	pool *Pool
+	opts   *Options
+	pool   *Pool
 }
 
 // Debug implements LoggerAPI.
@@ -33,35 +33,37 @@ func (l *logfmtLogger) Warn(msg string, kv ...any) {
 
 // With implements loggerAPI.
 func (l *logfmtLogger) With(kv ...any) Logger {
-	attrs := make([]any, 0, len(kv) + len(l.kv))
+	attrs := make([]any, 0, len(kv)+len(l.kv))
 	attrs = append(attrs, l.kv...)
 	attrs = append(attrs, kv...)
 
 	return &logfmtLogger{
-		kv: attrs,
-		pool:    l.pool,
+		kv:   attrs,
+		pool: l.pool,
 		opts: l.opts,
 	}
 }
 
 func (l *logfmtLogger) Slog() *slog.Logger {
 	kv := make([]slog.Attr, 0, len(l.kv))
-	for i := 1; i < len(l.kv); i+=2 {
+	for i := 1; i < len(l.kv); i += 2 {
 		kv = append(kv, slog.Any(l.kv[i-1].(string), l.kv[i]))
 	}
 
 	return slog.New(&logfmtSlog{
 		kv:   kv,
-		pool:  l.pool,
+		pool: l.pool,
 		opts: l.opts,
 	})
 }
 
 // Clone implements loggerAPI.
 func (l *logfmtLogger) Clone() *loggerBuilder {
+	optsCopy := *l.opts
 	return &loggerBuilder{
-		options: l.opts,
-		prefix: l.prefix,
+		options: &optsCopy,
+		prefix:  l.prefix,
+		kv:      l.kv,
 	}
 }
 
@@ -74,8 +76,16 @@ func (l *logfmtLogger) handleLog(level slog.Level, msg string, kv ...any) error 
 
 	buf := l.pool.Get()
 
-	buf.AppendCaller(2 + l.opts.SkipCallerFrames)
-	buf.AppendComponentSeparator()
+	needSep := false
+	if buf.AppendTimestamp() {
+		needSep = true
+	}
+	if buf.AppendCaller(2 + l.opts.SkipCallerFrames) {
+		needSep = true
+	}
+	if needSep {
+		buf.AppendComponentSeparator()
+	}
 
 	buf.AppendLogLevel(level)
 	buf.AppendComponentSeparator()

--- a/logger.go
+++ b/logger.go
@@ -54,7 +54,7 @@ func New() *loggerBuilder {
 
 func (l *loggerBuilder) JSON() Logger {
 	return &jsonLogger{
-		kv:     nil,
+		kv:     l.kv,
 		prefix: l.prefix,
 		opts:   l.options,
 		pool: newPool(&bufferPoolOptions{
@@ -68,7 +68,7 @@ func (l *loggerBuilder) JSON() Logger {
 
 func (l *loggerBuilder) Logfmt() Logger {
 	return &logfmtLogger{
-		kv:   nil,
+		kv:   l.kv,
 		opts: l.options,
 		pool: newPool(&bufferPoolOptions{
 			WithTimestamp: l.options.WithTimestamp,
@@ -81,7 +81,7 @@ func (l *loggerBuilder) Logfmt() Logger {
 
 func (l *loggerBuilder) Console() Logger {
 	return &consoleLogger{
-		kv:   nil,
+		kv:   l.kv,
 		opts: l.options,
 		pool: newPool(&bufferPoolOptions{
 			WithTimestamp: l.options.WithTimestamp,
@@ -141,6 +141,7 @@ func (l *loggerBuilder) Verbosity(n int) *loggerBuilder {
 type loggerBuilder struct {
 	prefix  string
 	options *Options
+	kv      []any
 }
 
 type Logger interface {
@@ -169,7 +170,6 @@ func Logfmt() Logger {
 func Console() Logger {
 	return New().Console()
 }
-
 var defaultLogger Logger
 
 func SetDefault(logger Logger) {

--- a/nixy.yml
+++ b/nixy.yml
@@ -1,0 +1,6 @@
+nixpkgs:
+  default: 050e09e091117c3d7328c7b2b7b577492c43c134
+
+packages:
+  - go
+  - graphviz

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -1,0 +1,60 @@
+package fastlog_test
+
+import (
+	"github.com/nxtcoder17/fastlog"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestConsole_OutputContainsMessage(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).Console()
+
+	logger.Info("hello world", "key", "value")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	if !strings.Contains(lines[0], "INFO") {
+		t.Errorf("expected INFO in: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "hello world") {
+		t.Errorf("expected 'hello world' in: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "key=value") {
+		t.Errorf("expected key=value in: %s", lines[0])
+	}
+}
+
+func TestConsole_AllLevels(t *testing.T) {
+	tests := []struct {
+		name  string
+		level slog.Level
+		fn    func(fastlog.Logger, string, ...any)
+	}{
+		{"Debug", slog.LevelDebug, fastlog.Logger.Debug},
+		{"Info", slog.LevelInfo, fastlog.Logger.Info},
+		{"Warn", slog.LevelWarn, fastlog.Logger.Warn},
+		{"Error", slog.LevelError, fastlog.Logger.Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cw := newCapture()
+			logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).LogLevel(tt.level).Console()
+
+			tt.fn(logger, "msg")
+
+			lines := cw.Lines()
+			if len(lines) != 1 {
+				t.Fatalf("expected 1 line, got %d", len(lines))
+			}
+			if !strings.Contains(lines[0], tt.level.String()) {
+				t.Errorf("expected %s in: %s", tt.level.String(), lines[0])
+			}
+		})
+	}
+}

--- a/tests/edge_cases_test.go
+++ b/tests/edge_cases_test.go
@@ -1,0 +1,237 @@
+package fastlog_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/nxtcoder17/fastlog"
+	"strings"
+	"testing"
+)
+
+func TestEdgeCases_NilValue(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "nil_key", nil)
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with nil value: %v", err)
+	}
+}
+
+func TestEdgeCases_Unicode(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "unicode", "こんにちは世界")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with unicode: %v", err)
+	}
+	if m["unicode"] != "こんにちは世界" {
+		t.Errorf("expected unicode value preserved, got %v", m["unicode"])
+	}
+}
+
+func TestEdgeCases_SpecialChars(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "special", `quotes "and" backslashes \ and	newlines
+here`)
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with special chars: %v\noutput: %s", err, lines[0])
+	}
+}
+
+func TestEdgeCases_EmptyAttrs(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with no attrs: %v", err)
+	}
+}
+
+func TestEdgeCases_UnbalancedKV(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Logf("panicked on unbalanced KV (acceptable): %v", r)
+		}
+	}()
+
+	logger.Info("msg", "only_key")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+}
+
+func TestEdgeCases_EmptyMessage(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with empty message: %v", err)
+	}
+}
+
+func TestEdgeCases_LargeAttrs(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	kv := make([]any, 0, 100)
+	for i := 0; i < 50; i++ {
+		kv = append(kv, fmt.Sprintf("key%d", i), fmt.Sprintf("value%d", i))
+	}
+	logger.Info("msg", kv...)
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with large attrs: %v", err)
+	}
+	if len(m) != 52 {
+		t.Errorf("expected 52 fields, got %d", len(m))
+	}
+}
+
+func TestEdgeCases_NestedMap(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "nested", map[string]any{
+		"a": 1,
+		"b": "two",
+	})
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with nested map: %v", err)
+	}
+}
+
+func TestEdgeCases_NestedSlice(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "slice", []any{1, "two", true})
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with nested slice: %v", err)
+	}
+}
+
+func TestEdgeCases_ErrorType(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "err", fmt.Errorf("something went wrong"))
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON with error type: %v", err)
+	}
+	if !strings.Contains(m["err"].(string), "something went wrong") {
+		t.Errorf("expected error message in output, got %v", m["err"])
+	}
+}
+
+func TestEdgeCases_BoolAttrs(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "true_val", true, "false_val", false)
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if m["true_val"] != true {
+		t.Errorf("expected true_val=true, got %v", m["true_val"])
+	}
+	if m["false_val"] != false {
+		t.Errorf("expected false_val=false, got %v", m["false_val"])
+	}
+}
+
+func TestEdgeCases_FloatAttrs(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg", "float64", 3.14159, "float32", float32(2.71))
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+}

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,0 +1,96 @@
+package fastlog_test
+
+import (
+	"encoding/json"
+	"github.com/nxtcoder17/fastlog"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestJSON_ValidOutput(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("hello", "key", "value", "num", 42)
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, lines[0])
+	}
+
+	if m["message"] != "hello" {
+		t.Errorf("expected message=hello, got %v", m["message"])
+	}
+	if m["key"] != "value" {
+		t.Errorf("expected key=value, got %v", m["key"])
+	}
+	if m["num"] != float64(42) {
+		t.Errorf("expected num=42, got %v", m["num"])
+	}
+}
+
+func TestJSON_AllLevels(t *testing.T) {
+	tests := []struct {
+		name  string
+		level slog.Level
+		fn    func(fastlog.Logger, string, ...any)
+	}{
+		{"Debug", slog.LevelDebug, fastlog.Logger.Debug},
+		{"Info", slog.LevelInfo, fastlog.Logger.Info},
+		{"Warn", slog.LevelWarn, fastlog.Logger.Warn},
+		{"Error", slog.LevelError, fastlog.Logger.Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cw := newCapture()
+			logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).LogLevel(tt.level).JSON()
+
+			tt.fn(logger, "msg", "k", "v")
+
+			lines := cw.Lines()
+			if len(lines) != 1 {
+				t.Fatalf("expected 1 line, got %d", len(lines))
+			}
+
+			var m map[string]any
+			if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+			if m["level"] != tt.level.String() {
+				t.Errorf("expected level=%s, got %v", tt.level.String(), m["level"])
+			}
+		})
+	}
+}
+
+func TestJSON_WithCaller(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(true).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("msg")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	caller, ok := m["caller"]
+	if !ok {
+		t.Fatal("expected caller field in JSON output")
+	}
+	if !strings.Contains(caller.(string), "json_test.go") {
+		t.Errorf("expected caller to contain test filename, got %v", caller)
+	}
+}

--- a/tests/level_test.go
+++ b/tests/level_test.go
@@ -1,0 +1,54 @@
+package fastlog_test
+
+import (
+	"github.com/nxtcoder17/fastlog"
+	"log/slog"
+	"testing"
+)
+
+func TestLogLevel_Filtering(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel slog.Level
+		call     func(fastlog.Logger)
+		expect   bool
+	}{
+		{"Debug_at_DebugLevel", slog.LevelDebug, func(l fastlog.Logger) { l.Debug("msg") }, true},
+		{"Info_at_DebugLevel", slog.LevelDebug, func(l fastlog.Logger) { l.Info("msg") }, true},
+		{"Debug_at_InfoLevel", slog.LevelInfo, func(l fastlog.Logger) { l.Debug("msg") }, false},
+		{"Info_at_InfoLevel", slog.LevelInfo, func(l fastlog.Logger) { l.Info("msg") }, true},
+		{"Warn_at_InfoLevel", slog.LevelInfo, func(l fastlog.Logger) { l.Warn("msg") }, true},
+		{"Debug_at_WarnLevel", slog.LevelWarn, func(l fastlog.Logger) { l.Debug("msg") }, false},
+		{"Info_at_WarnLevel", slog.LevelWarn, func(l fastlog.Logger) { l.Info("msg") }, false},
+		{"Warn_at_WarnLevel", slog.LevelWarn, func(l fastlog.Logger) { l.Warn("msg") }, true},
+		{"Debug_at_ErrorLevel", slog.LevelError, func(l fastlog.Logger) { l.Debug("msg") }, false},
+		{"Info_at_ErrorLevel", slog.LevelError, func(l fastlog.Logger) { l.Info("msg") }, false},
+		{"Warn_at_ErrorLevel", slog.LevelError, func(l fastlog.Logger) { l.Warn("msg") }, false},
+		{"Error_at_ErrorLevel", slog.LevelError, func(l fastlog.Logger) { l.Error("msg") }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cw := newCapture()
+			logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).LogLevel(tt.logLevel).JSON()
+
+			tt.call(logger)
+
+			hasOutput := len(cw.Lines()) > 0
+			if hasOutput != tt.expect {
+				t.Errorf("expected output=%v, got output=%v (lines=%d)", tt.expect, hasOutput, len(cw.Lines()))
+			}
+		})
+	}
+}
+
+func TestDebugMode(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).DebugMode(true).JSON()
+
+	logger.Debug("debug msg")
+
+	if len(cw.Lines()) != 1 {
+		t.Errorf("expected Debug to produce output with DebugMode(true), got %d lines", len(cw.Lines()))
+	}
+}

--- a/tests/logfmt_test.go
+++ b/tests/logfmt_test.go
@@ -1,0 +1,62 @@
+package fastlog_test
+
+import (
+	"fmt"
+	"github.com/nxtcoder17/fastlog"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLogfmt_ValidOutput(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).Logfmt()
+
+	logger.Info("hello", "key", "value", "num", 42)
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	line := lines[0]
+	if !strings.Contains(line, "message=hello") {
+		t.Errorf("expected message=hello in: %s", line)
+	}
+	if !strings.Contains(line, "key=value") {
+		t.Errorf("expected key=value in: %s", line)
+	}
+	if !strings.Contains(line, "num=42") {
+		t.Errorf("expected num=42 in: %s", line)
+	}
+}
+
+func TestLogfmt_AllLevels(t *testing.T) {
+	tests := []struct {
+		name  string
+		level slog.Level
+		fn    func(fastlog.Logger, string, ...any)
+	}{
+		{"Debug", slog.LevelDebug, fastlog.Logger.Debug},
+		{"Info", slog.LevelInfo, fastlog.Logger.Info},
+		{"Warn", slog.LevelWarn, fastlog.Logger.Warn},
+		{"Error", slog.LevelError, fastlog.Logger.Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cw := newCapture()
+			logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).LogLevel(tt.level).Logfmt()
+
+			tt.fn(logger, "msg", "k", "v")
+
+			lines := cw.Lines()
+			if len(lines) != 1 {
+				t.Fatalf("expected 1 line, got %d", len(lines))
+			}
+			if !strings.Contains(lines[0], fmt.Sprintf("level=%s", tt.level.String())) {
+				t.Errorf("expected level=%s in: %s", tt.level.String(), lines[0])
+			}
+		})
+	}
+}

--- a/tests/prefix_test.go
+++ b/tests/prefix_test.go
@@ -1,0 +1,23 @@
+package fastlog_test
+
+import (
+	"github.com/nxtcoder17/fastlog"
+	"strings"
+	"testing"
+)
+
+func TestPrefix(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).Prefix("myprefix").JSON().Slog()
+
+	logger.Info("msg", "key", "value")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	if !strings.Contains(lines[0], "myprefix.key") {
+		t.Errorf("expected prefixed key in: %s", lines[0])
+	}
+}

--- a/tests/quickstart_test.go
+++ b/tests/quickstart_test.go
@@ -1,0 +1,52 @@
+package fastlog_test
+
+import (
+	"encoding/json"
+	"github.com/nxtcoder17/fastlog"
+	"strings"
+	"testing"
+)
+
+func TestQuickStart_Console(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).Console()
+
+	logger.Info("test")
+
+	if len(cw.Lines()) == 0 {
+		t.Error("Console() should produce output")
+	}
+}
+
+func TestQuickStart_JSON(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	logger.Info("test")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+}
+
+func TestQuickStart_Logfmt(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).Logfmt()
+
+	logger.Info("test")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	if !strings.Contains(lines[0], "message=test") {
+		t.Errorf("expected message=test in: %s", lines[0])
+	}
+}

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -1,0 +1,31 @@
+package fastlog_test
+
+import (
+	"bytes"
+	"strings"
+)
+
+// --- Helper: capture output from logger ---
+type captureWriter struct {
+	buf bytes.Buffer
+}
+
+func (w *captureWriter) Write(p []byte) (n int, err error) {
+	return w.buf.Write(p)
+}
+
+func (w *captureWriter) String() string {
+	return w.buf.String()
+}
+
+func (w *captureWriter) Lines() []string {
+	s := strings.TrimSpace(w.buf.String())
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+func newCapture() *captureWriter {
+	return &captureWriter{}
+}

--- a/tests/slog_test.go
+++ b/tests/slog_test.go
@@ -1,0 +1,89 @@
+package fastlog_test
+
+import (
+	"encoding/json"
+	"github.com/nxtcoder17/fastlog"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestSlog_JSON(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON().Slog()
+
+	logger.Info("hello", "key", "value")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if m["message"] != "hello" {
+		t.Errorf("expected message=hello, got %v", m["message"])
+	}
+	if m["key"] != "value" {
+		t.Errorf("expected key=value, got %v", m["key"])
+	}
+}
+
+func TestSlog_WithAttrs(t *testing.T) {
+	cw := newCapture()
+	base := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON().Slog()
+
+	derived := base.With("base_attr", "base_value")
+	derived.Info("msg", "call_attr", "call_value")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	json.Unmarshal([]byte(lines[0]), &m)
+
+	if m["base_attr"] != "base_value" {
+		t.Errorf("expected base_attr=base_value, got %v", m["base_attr"])
+	}
+	if m["call_attr"] != "call_value" {
+		t.Errorf("expected call_attr=call_value, got %v", m["call_attr"])
+	}
+}
+
+func TestSlog_WithGroup(t *testing.T) {
+	cw := newCapture()
+	base := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON().Slog()
+
+	grouped := base.WithGroup("group").With("key", "value")
+	grouped.Info("msg")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	if !strings.Contains(lines[0], "group.key") {
+		t.Errorf("expected group.key in: %s", lines[0])
+	}
+}
+
+func TestSlog_LevelFiltering(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).LogLevel(slog.LevelWarn).JSON().Slog()
+
+	logger.Info("should be suppressed")
+	logger.Warn("should appear")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line (Info suppressed), got %d", len(lines))
+	}
+	if len(lines) > 0 && !strings.Contains(lines[0], "should appear") {
+		t.Errorf("expected 'should appear' in output, got: %s", lines[0])
+	}
+}

--- a/tests/timestamp_test.go
+++ b/tests/timestamp_test.go
@@ -1,0 +1,179 @@
+package fastlog_test
+
+import (
+	"encoding/json"
+	"github.com/nxtcoder17/fastlog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTimestamp_AllLoggers(t *testing.T) {
+	formats := []struct {
+		name   string
+		format string
+	}{
+		{"RFC3339", time.RFC3339},
+		{"RFC3339Nano", time.RFC3339Nano},
+		{"DateTime", time.DateTime},
+		{"DateOnly", time.DateOnly},
+		{"TimeOnly", time.TimeOnly},
+		{"RFC1123", time.RFC1123},
+		{"RFC1123Z", time.RFC1123Z},
+		{"RFC822", time.RFC822},
+		{"RFC822Z", time.RFC822Z},
+		{"Kitchen", time.Kitchen},
+		{"ANSIC", time.ANSIC},
+		{"Custom_SlashDate", "2006/01/02 15:04:05"},
+		{"Custom_DashDate", "02-01-2006 15:04:05"},
+		{"Custom_MonthName", "Jan 2, 2006 15:04:05"},
+		{"Custom_Millis", "2006-01-02T15:04:05.000Z"},
+	}
+
+	originalFormat := fastlog.TimestampFormat
+
+	t.Run("JSON", func(t *testing.T) {
+		for _, tf := range formats {
+			t.Run(tf.name, func(t *testing.T) {
+				fastlog.TimestampFormat = tf.format
+				t.Cleanup(func() {
+					fastlog.TimestampFormat = originalFormat
+				})
+
+				cw := newCapture()
+				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).JSON()
+
+				logger.Info("msg")
+
+				lines := cw.Lines()
+				if len(lines) != 1 {
+					t.Fatalf("expected 1 line, got %d", len(lines))
+				}
+
+				var m map[string]any
+				if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
+					t.Fatalf("invalid JSON: %v", err)
+				}
+
+				ts, ok := m["timestamp"]
+				if !ok {
+					t.Fatal("expected timestamp field")
+				}
+				tsStr, ok := ts.(string)
+				if !ok {
+					t.Fatalf("expected timestamp to be string, got %T", ts)
+				}
+
+				assertValidTimestamp(t, tsStr, tf.format)
+			})
+		}
+	})
+
+	t.Run("Logfmt", func(t *testing.T) {
+		for _, tf := range formats {
+			t.Run(tf.name, func(t *testing.T) {
+				fastlog.TimestampFormat = tf.format
+				t.Cleanup(func() {
+					fastlog.TimestampFormat = originalFormat
+				})
+
+				cw := newCapture()
+				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).Logfmt()
+
+				logger.Info("msg")
+
+				lines := cw.Lines()
+				if len(lines) != 1 {
+					t.Fatalf("expected 1 line, got %d", len(lines))
+				}
+
+				tsStr := extractLogfmtTimestamp(lines[0])
+				if tsStr == "" {
+					t.Fatal("expected non-empty timestamp")
+				}
+
+				assertValidTimestamp(t, tsStr, tf.format)
+			})
+		}
+	})
+
+	t.Run("Console", func(t *testing.T) {
+		skipFormats := map[string]bool{
+			"DateTime":         true,
+			"RFC1123":          true,
+			"RFC1123Z":         true,
+			"RFC822":           true,
+			"RFC822Z":          true,
+			"ANSIC":            true,
+			"Custom_SlashDate": true,
+			"Custom_DashDate":  true,
+			"Custom_MonthName": true,
+		}
+
+		for _, tf := range formats {
+			t.Run(tf.name, func(t *testing.T) {
+				if skipFormats[tf.name] {
+					t.Skip("console output is space-delimited, can't extract timestamps containing spaces")
+				}
+				fastlog.TimestampFormat = tf.format
+				t.Cleanup(func() {
+					fastlog.TimestampFormat = originalFormat
+				})
+
+				cw := newCapture()
+				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).Console()
+
+				logger.Info("msg")
+
+				lines := cw.Lines()
+				if len(lines) != 1 {
+					t.Fatalf("expected 1 line, got %d", len(lines))
+				}
+
+				parts := strings.SplitN(lines[0], " ", 2)
+				if len(parts) < 1 {
+					t.Fatal("empty console output")
+				}
+				tsStr := parts[0]
+
+				assertValidTimestamp(t, tsStr, tf.format)
+			})
+		}
+	})
+}
+
+func assertValidTimestamp(t *testing.T, tsStr, format string) {
+	t.Helper()
+
+	if tsStr == "" {
+		t.Fatal("expected non-empty timestamp")
+	}
+
+	parsed, err := time.Parse(format, tsStr)
+	if err != nil {
+		t.Errorf("failed to parse timestamp %q with format %q: %v", tsStr, format, err)
+	}
+	if parsed.IsZero() {
+		t.Errorf("parsed timestamp is zero")
+	}
+}
+
+func extractLogfmtTimestamp(line string) string {
+	idx := strings.Index(line, "timestamp=")
+	if idx == -1 {
+		return ""
+	}
+	val := line[idx+len("timestamp="):]
+	if strings.HasPrefix(val, "\"") {
+		end := strings.Index(val[1:], "\"")
+		if end == -1 {
+			return ""
+		}
+		return val[1 : end+1]
+	}
+	end := strings.IndexAny(val, " \n")
+	if end == -1 {
+		return strings.TrimSpace(val)
+	}
+	return val[:end]
+}

--- a/tests/timestamp_test.go
+++ b/tests/timestamp_test.go
@@ -10,24 +10,26 @@ import (
 
 func TestTimestamp_AllLoggers(t *testing.T) {
 	formats := []struct {
-		name   string
-		format string
+		name             string
+		format           string
+		timestampEnabled bool
 	}{
-		{"RFC3339", time.RFC3339},
-		{"RFC3339Nano", time.RFC3339Nano},
-		{"DateTime", time.DateTime},
-		{"DateOnly", time.DateOnly},
-		{"TimeOnly", time.TimeOnly},
-		{"RFC1123", time.RFC1123},
-		{"RFC1123Z", time.RFC1123Z},
-		{"RFC822", time.RFC822},
-		{"RFC822Z", time.RFC822Z},
-		{"Kitchen", time.Kitchen},
-		{"ANSIC", time.ANSIC},
-		{"Custom_SlashDate", "2006/01/02 15:04:05"},
-		{"Custom_DashDate", "02-01-2006 15:04:05"},
-		{"Custom_MonthName", "Jan 2, 2006 15:04:05"},
-		{"Custom_Millis", "2006-01-02T15:04:05.000Z"},
+		{"Timestamp Disabled", time.RFC3339, false},
+		{"RFC3339", time.RFC3339, true},
+		{"RFC3339Nano", time.RFC3339Nano, true},
+		{"DateTime", time.DateTime, true},
+		{"DateOnly", time.DateOnly, true},
+		{"TimeOnly", time.TimeOnly, true},
+		{"RFC1123", time.RFC1123, true},
+		{"RFC1123Z", time.RFC1123Z, true},
+		{"RFC822", time.RFC822, true},
+		{"RFC822Z", time.RFC822Z, true},
+		{"Kitchen", time.Kitchen, true},
+		{"ANSIC", time.ANSIC, true},
+		{"Custom_SlashDate", "2006/01/02 15:04:05", true},
+		{"Custom_DashDate", "02-01-2006 15:04:05", true},
+		{"Custom_MonthName", "Jan 2, 2006 15:04:05", true},
+		{"Custom_Millis", "2006-01-02T15:04:05.000Z", true},
 	}
 
 	originalFormat := fastlog.TimestampFormat
@@ -41,7 +43,7 @@ func TestTimestamp_AllLoggers(t *testing.T) {
 				})
 
 				cw := newCapture()
-				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).JSON()
+				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(tf.timestampEnabled).Colors(false).JSON()
 
 				logger.Info("msg")
 
@@ -53,6 +55,14 @@ func TestTimestamp_AllLoggers(t *testing.T) {
 				var m map[string]any
 				if err := json.Unmarshal([]byte(lines[0]), &m); err != nil {
 					t.Fatalf("invalid JSON: %v", err)
+				}
+
+				if !tf.timestampEnabled {
+					_, ok := m["timestamp"]
+					if ok {
+						t.Fatal("never expected timestamp field, when timestamp option is disabled")
+					}
+					return
 				}
 
 				ts, ok := m["timestamp"]
@@ -78,7 +88,7 @@ func TestTimestamp_AllLoggers(t *testing.T) {
 				})
 
 				cw := newCapture()
-				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).Logfmt()
+				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(tf.timestampEnabled).Colors(false).Logfmt()
 
 				logger.Info("msg")
 
@@ -88,6 +98,14 @@ func TestTimestamp_AllLoggers(t *testing.T) {
 				}
 
 				tsStr := extractLogfmtTimestamp(lines[0])
+
+				if !tf.timestampEnabled {
+					if tsStr != "" {
+						t.Fatal("never expected non-empty timestamp, when timestamp option is disabled")
+					}
+					return
+				}
+
 				if tsStr == "" {
 					t.Fatal("expected non-empty timestamp")
 				}
@@ -98,30 +116,15 @@ func TestTimestamp_AllLoggers(t *testing.T) {
 	})
 
 	t.Run("Console", func(t *testing.T) {
-		skipFormats := map[string]bool{
-			"DateTime":         true,
-			"RFC1123":          true,
-			"RFC1123Z":         true,
-			"RFC822":           true,
-			"RFC822Z":          true,
-			"ANSIC":            true,
-			"Custom_SlashDate": true,
-			"Custom_DashDate":  true,
-			"Custom_MonthName": true,
-		}
-
 		for _, tf := range formats {
 			t.Run(tf.name, func(t *testing.T) {
-				if skipFormats[tf.name] {
-					t.Skip("console output is space-delimited, can't extract timestamps containing spaces")
-				}
 				fastlog.TimestampFormat = tf.format
 				t.Cleanup(func() {
 					fastlog.TimestampFormat = originalFormat
 				})
 
 				cw := newCapture()
-				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).Console()
+				logger := fastlog.New().Writer(cw).Caller(false).Timestamp(tf.timestampEnabled).Colors(false).Console()
 
 				logger.Info("msg")
 
@@ -130,12 +133,19 @@ func TestTimestamp_AllLoggers(t *testing.T) {
 					t.Fatalf("expected 1 line, got %d", len(lines))
 				}
 
-				parts := strings.SplitN(lines[0], " ", 2)
-				if len(parts) < 1 {
-					t.Fatal("empty console output")
+				parts := strings.Split(lines[0], " | ")
+				if len(parts) < 2 {
+					t.Fatalf("unexpected console output format: %q", lines[0])
 				}
-				tsStr := parts[0]
 
+				if !tf.timestampEnabled {
+					if parts[0] != "INFO" {
+						t.Fatalf("never expected timestamp when timestamp option is disabled, but got: %q", parts[0])
+					}
+					return
+				}
+
+				tsStr := parts[0]
 				assertValidTimestamp(t, tsStr, tf.format)
 			})
 		}

--- a/tests/with_test.go
+++ b/tests/with_test.go
@@ -1,0 +1,108 @@
+package fastlog_test
+
+import (
+	"encoding/json"
+	"github.com/nxtcoder17/fastlog"
+	"log/slog"
+	"testing"
+)
+
+func TestWith_Immutability(t *testing.T) {
+	cwBase := newCapture()
+	cwDerived := newCapture()
+
+	base := fastlog.New().Writer(cwBase).Caller(false).Timestamp(false).Colors(false).JSON()
+
+	derived := base.With("extra", "attr")
+
+	derivedIsolated := derived.Clone().Writer(cwDerived).JSON()
+
+	base.Info("base msg")
+	derivedIsolated.Info("derived msg")
+
+	linesBase := cwBase.Lines()
+	if len(linesBase) != 1 {
+		t.Fatalf("expected 1 line from base, got %d", len(linesBase))
+	}
+	var mBase map[string]any
+	json.Unmarshal([]byte(linesBase[0]), &mBase)
+	if _, ok := mBase["extra"]; ok {
+		t.Error("base logger should not have 'extra' attr after With()")
+	}
+
+	linesDerived := cwDerived.Lines()
+	if len(linesDerived) != 1 {
+		t.Fatalf("expected 1 line from derived, got %d", len(linesDerived))
+	}
+	var mDerived map[string]any
+	json.Unmarshal([]byte(linesDerived[0]), &mDerived)
+	if mDerived["extra"] != "attr" {
+		t.Errorf("derived logger should have extra=attr, got %v", mDerived["extra"])
+	}
+}
+
+func TestWith_Chaining(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(false).Colors(false).JSON().
+		With("a", "1").
+		With("b", "2")
+
+	logger.Info("msg")
+
+	lines := cw.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	json.Unmarshal([]byte(lines[0]), &m)
+
+	if m["a"] != "1" {
+		t.Errorf("expected a=1, got %v", m["a"])
+	}
+	if m["b"] != "2" {
+		t.Errorf("expected b=2, got %v", m["b"])
+	}
+}
+
+func TestClone_Independent(t *testing.T) {
+	cw1 := newCapture()
+	cw2 := newCapture()
+
+	logger := fastlog.New().Writer(cw1).Caller(false).Timestamp(false).Colors(false).JSON()
+	clonedBuilder := logger.Clone().Writer(cw2)
+	cloned := clonedBuilder.JSON()
+
+	logger.Info("original")
+	cloned.Info("cloned")
+
+	if len(cw1.Lines()) != 1 {
+		t.Errorf("expected 1 line from original, got %d", len(cw1.Lines()))
+	}
+	if len(cw2.Lines()) != 1 {
+		t.Errorf("expected 1 line from cloned, got %d", len(cw2.Lines()))
+	}
+}
+
+func TestClone_PreservesSettings(t *testing.T) {
+	cw := newCapture()
+	logger := fastlog.New().Writer(cw).Caller(false).Timestamp(true).Colors(false).LogLevel(slog.LevelDebug).JSON()
+	cloned := logger.Clone()
+
+	clonedWriter := newCapture()
+	clonedLogger := cloned.Writer(clonedWriter).JSON()
+
+	clonedLogger.Debug("debug msg")
+
+	lines := clonedWriter.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var m map[string]any
+	json.Unmarshal([]byte(lines[0]), &m)
+
+	if _, ok := m["timestamp"]; !ok {
+		t.Error("cloned logger should preserve timestamp setting")
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive tests and small behavior refinements for fastlog across JSON, logfmt, console, and slog integrations.

Enhancements:
- Preserve builder kv state and clone logger options/attributes safely across JSON, logfmt, and console loggers.
- Refine timestamp and caller emission logic to avoid extra separators and support configurable formats in all formats.
- Improve slog handler grouping and prefix handling for JSON, logfmt, and console handlers.
- Adjust color handling and buffer options wiring while keeping default options consistent.

Tests:
- Add tests covering JSON, logfmt, console, and slog outputs including all log levels and level filtering.
- Add tests for timestamp formatting across multiple layouts and formats for all logger types.
- Add tests for logger prefixing, With/Clone behavior, and quickstart-style basic usage.
- Add edge case tests for nils, unicode, special characters, nested structures, and various scalar types.